### PR TITLE
pekko-grpc 1.0.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up JDK 17
-        uses: coursier/setup-action@v1.3.0
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
         with:
-          jvm: temurin:1.17
+          distribution: temurin
+          java-version: 11
 
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.4.0

--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -1,6 +1,6 @@
 name = pekko-grpc-quickstart-scala
 description = Pekko gRPC is a toolkit for building streaming gRPC servers and clients on top of Pekko Streams. This simple application will get you started building gRPC based systems with Scala. This app uses Pekko, Scala, and ScalaTest.
-pekko_grpc_version=1.0.1
+pekko_grpc_version=1.0.2
 pekko_version=1.0.2
 sbt_version=maven(org.scala-sbt, sbt, stable)
 scala_major_version=2.13

--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -1,5 +1,5 @@
 name = pekko-grpc-quickstart-scala
-description = Pekko gRPC is a toolkit for building streaming gRPC servers and clients on top of Pekko Streams. This simple application will get you started building gRPC based systems with Scala. This app uses Pekko, Scala, and ScalaTest.
+description = Apache Pekko gRPC is a toolkit for building streaming gRPC servers and clients on top of Pekko Streams. This simple application will get you started building gRPC based systems with Scala. This app uses Pekko, Scala, and ScalaTest.
 pekko_grpc_version=1.0.2
 pekko_version=1.0.2
 sbt_version=maven(org.scala-sbt, sbt, stable)


### PR DESCRIPTION
the build failure in CI is pre-existing and I would like to treat it as a separate issue - see https://github.com/apache/incubator-pekko-grpc-quickstart-scala.g8/issues