### PR TITLE
use java 11 in CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up JDK 17
-        uses: coursier/setup-action@v1.3.0
+      - name: Setup Java 11
+        uses: actions/setup-java@v4
         with:
-          jvm: temurin:1.17
+          distribution: temurin
+          java-version: 11
 
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.4.0


### PR DESCRIPTION
We're getting issues in CI with `sbt paradox` when using Java 17.